### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,13 @@
 setting.py
+### Web ###
+*.asp
+*.cer
+*.csr
+*.css
+*.htm
+*.html
+*.js
+*.jsp
+*.php
+*.rss
+*.xhtml


### PR DESCRIPTION
¿Qué ha cambiado?
Agregamos al gitignore soporte para web
- [ ] Frontend
- [ ] Backend
- [X] Configuración del server

# ¿Cómo puedo porbar los cambios?
Por ejemplo los archivos y la carpeta php no se suben al repo. Ver el archivo gitignore completo.